### PR TITLE
Remove deprecated enable/disable recipe API calls

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -114,18 +114,6 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             ElevatedButton(
               onPressed: () async {
-                enableRecipe();
-              },
-              child: const Text('Enable Recipe'),
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                disableRecipe();
-              },
-              child: const Text('Disable Recipe'),
-            ),
-            ElevatedButton(
-              onPressed: () async {
                 getProfile();
               },
               child: const Text('Get Profile'),
@@ -264,36 +252,6 @@ class _MyHomePageState extends State<MyHomePage> {
         extraInfo: "extraInfo");
 
     var response = await PylonsWallet.instance.txUpdateRecipe(recipe);
-
-    log('From App $response', name: 'pylons_sdk');
-
-    if (response.success) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text("Recipe updated")));
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Recipe update error : ${response.error}")));
-    }
-  }
-
-  void enableRecipe() async {
-    var response = await PylonsWallet.instance
-        .txEnableRecipe(cookBookId, recipeId, "v1.0.3");
-
-    log('From App $response', name: 'pylons_sdk');
-
-    if (response.success) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text("Recipe updated")));
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Recipe update error : ${response.error}")));
-    }
-  }
-
-  void disableRecipe() async {
-    var response = await PylonsWallet.instance
-        .txDisableRecipe(cookBookId, recipeId, "v1.0.4");
 
     log('From App $response', name: 'pylons_sdk');
 

--- a/lib/src/core/constants/strings.dart
+++ b/lib/src/core/constants/strings.dart
@@ -12,8 +12,6 @@ class Strings {
   static const String TX_CREATE_RECIPE = 'txCreateRecipe';
   static const String TX_UPDATE_COOKBOOK = 'txUpdateCookbook';
   static const String TX_UPDATE_RECIPE = 'txUpdateRecipe';
-  static const String TX_ENABLE_RECIPE = 'txEnableRecipe';
-  static const String TX_DISABLE_RECIPE = 'txDisableRecipe';
   static const String TX_EXECUTE_RECIPE = 'txExecuteRecipe';
   static const String TX_PLACE_FOR_SALE = 'txPlaceForSale';
   static const String ERR_NODE = 'node';

--- a/lib/src/pylons_wallet.dart
+++ b/lib/src/pylons_wallet.dart
@@ -332,22 +332,6 @@ abstract class PylonsWallet {
   /// exception will be passed directly.
   Future<SDKIPCResponse> txCreateRecipe(Recipe recipe);
 
-  /// DEPRECATED, DO NOT USE
-  ///
-  /// Use UpdateRecipe and edit the enabled/disabled field instead.
-  ///
-  /// TODO: Remove this.
-  Future<SDKIPCResponse> txDisableRecipe(
-      String cookbookId, String recipeId, String version);
-
-  /// DEPRECATED, DO NOT USE
-  ///
-  /// Use UpdateRecipe and edit the enabled/disabled field instead.
-  ///
-  /// TODO: Remove this.
-  Future<SDKIPCResponse> txEnableRecipe(
-      String cookBookId, String recipeId, String version);
-
   /// Async: Creates a transaction to execute the recipe with coordinates
   /// [cookbookId] : [recipeName] against the current profile.
   ///

--- a/lib/src/pylons_wallet/pylons_wallet_impl.dart
+++ b/lib/src/pylons_wallet/pylons_wallet_impl.dart
@@ -145,20 +145,6 @@ class PylonsWalletImpl implements PylonsWallet {
   }
 
   @override
-  Future<SDKIPCResponse> txDisableRecipe(String cookbookId, String recipeId, String version) async {
-    return Future<SDKIPCResponse>.sync(() async {
-      return await _dispatch(Strings.TX_DISABLE_RECIPE, jsonEncode({Strings.COOKBOOK_ID: cookbookId, Strings.RECIPE_ID: recipeId, Strings.VERSION: version}));
-    });
-  }
-
-  @override
-  Future<SDKIPCResponse> txEnableRecipe(String cookbookId, String recipeId, String version) async {
-    return Future<SDKIPCResponse>.sync(() async {
-      return await _dispatch(Strings.TX_ENABLE_RECIPE, jsonEncode({Strings.COOKBOOK_ID: cookbookId, Strings.RECIPE_ID: recipeId, Strings.VERSION: version}));
-    });
-  }
-
-  @override
   Future<SDKIPCResponse> txExecuteRecipe(
       {required String cookbookId, required String recipeName, required List<String> itemIds, required int coinInputIndex, required List<PaymentInfo> paymentInfo}) async {
     return Future.sync(() async {

--- a/test/pylons_wallet/pylons_wallet_impl_test.dart
+++ b/test/pylons_wallet/pylons_wallet_impl_test.dart
@@ -22,8 +22,6 @@ void main() {
   getRecipesTest();
   createCookBookTest();
   executeRecipeTest();
-  enableRecipeTest();
-  disableRecipeTest();
   updateRecipeTest();
   updateCookBookTest();
   createRecipeTest();
@@ -117,49 +115,6 @@ void mockChannelHandler() {
   });
 
 
-}
-
-void enableRecipeTest() {
-  test('should enable recipe in the wallet', () async {
-    mockChannelHandler();
-
-
-
-    var uniLink = MockUniLinksPlatform();
-    when(uniLink.linkStream).thenAnswer((realInvocation) => Stream<String?>.value('Jawad'));
-    var pylonsWallet = PylonsWalletImpl(host: MOCK_HOST, uniLink: uniLink);
-
-
-    Future.delayed(Duration(seconds: 1), () {
-      final sdkResponse = SDKIPCResponse(success: true, error: '', data: '', errorCode: '', action: Strings.TX_ENABLE_RECIPE);
-      responseCompleters[Strings.TX_ENABLE_RECIPE]!.complete(sdkResponse);
-    });
-
-    var response = await pylonsWallet.txEnableRecipe(MOCK_COOKBOOK_ID, MOCK_RECIPE_ID, MOCK_VERSION);
-
-    expect(true, response.success);
-    expect(response.action, Strings.TX_ENABLE_RECIPE);
-  });
-}
-
-void disableRecipeTest() {
-  test('should disable recipe in the wallet', () async {
-    mockChannelHandler();
-
-    var uniLink = MockUniLinksPlatform();
-    when(uniLink.linkStream).thenAnswer((realInvocation) => Stream<String?>.value('Cr305'));
-    var pylonsWallet = PylonsWalletImpl(host: MOCK_HOST, uniLink: uniLink);
-
-    Future.delayed(Duration(seconds: 1), () {
-      final sdkResponse = SDKIPCResponse(success: true, error: '', data: '', errorCode: '', action: Strings.TX_DISABLE_RECIPE);
-      responseCompleters[Strings.TX_DISABLE_RECIPE]!.complete(sdkResponse);
-    });
-
-    var response = await pylonsWallet.txDisableRecipe(MOCK_COOKBOOK_ID, MOCK_RECIPE_ID, MOCK_VERSION);
-
-    expect(true, response.success);
-    expect(response.action, Strings.TX_DISABLE_RECIPE);
-  });
 }
 
 void executeRecipeTest() {


### PR DESCRIPTION
As discussed earlier. Code's all pretty clean and modular, so this wasn't really a big issue to tackle