### PR TITLE
Add an sdk func which redirects user to the Store

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -159,6 +159,12 @@ class _MyHomePageState extends State<MyHomePage> {
               },
               child: const Text('Place for sale'),
             ),
+            ElevatedButton(
+              onPressed: () async {
+                goToInstall();
+              },
+              child: const Text('Go to Install'),
+            ),
           ],
         ),
       ),
@@ -375,5 +381,14 @@ class _MyHomePageState extends State<MyHomePage> {
     );
     var sdkResponse = await PylonsWallet.instance.txPlaceForSale(item, 100);
     log(sdkResponse.toString(), name: 'pylons_sdk');
+  }
+
+  void goToInstall() async {
+    final isAlreadyInstalled = await PylonsWallet.instance.exists();
+    if (isAlreadyInstalled) {
+      log("Pylons Wallet already installed.", name: 'pylons_sdk');
+    } else {
+      PylonsWallet.instance.goToInstall();
+    }
   }
 }

--- a/lib/src/core/constants/strings.dart
+++ b/lib/src/core/constants/strings.dart
@@ -57,5 +57,5 @@ const kRecipeDescriptionLength = 20;
 
 const kPlayStoreUrl =
     'https://play.google.com/store/apps/details?id=tech.pylons.wallet';
-//TODO set apple appstore url here
-const kAppStoreUrl = 'https://';
+const kAppStoreUrl =
+    'https://apps.apple.com/app/1598732789';

--- a/lib/src/core/constants/strings.dart
+++ b/lib/src/core/constants/strings.dart
@@ -57,5 +57,4 @@ const kRecipeDescriptionLength = 20;
 
 const kPlayStoreUrl =
     'https://play.google.com/store/apps/details?id=tech.pylons.wallet';
-const kAppStoreUrl =
-    'https://apps.apple.com/app/1598732789';
+const kAppStoreUrl = 'https://apps.apple.com/app/1598732789';

--- a/lib/src/core/constants/strings.dart
+++ b/lib/src/core/constants/strings.dart
@@ -55,6 +55,7 @@ const kRecipeNameLength = 8;
 
 const kRecipeDescriptionLength = 20;
 
-const kPlayStoreUrl = 'https://play.google.com/store/apps/details?id=tech.pylons.wallet';
+const kPlayStoreUrl =
+    'https://play.google.com/store/apps/details?id=tech.pylons.wallet';
 //TODO set apple appstore url here
 const kAppStoreUrl = 'https://';

--- a/lib/src/core/constants/strings.dart
+++ b/lib/src/core/constants/strings.dart
@@ -54,3 +54,7 @@ class Strings {
 const kRecipeNameLength = 8;
 
 const kRecipeDescriptionLength = 20;
+
+const kPlayStoreUrl = 'https://play.google.com/store/apps/details?id=tech.pylons.wallet';
+//TODO set apple appstore url here
+const kAppStoreUrl = 'https://';

--- a/lib/src/pylons_wallet.dart
+++ b/lib/src/pylons_wallet.dart
@@ -79,6 +79,9 @@ abstract class PylonsWallet {
   /// Async: Returns true if an IPC target exists. False otherwise.
   Future<bool> exists();
 
+  /// Redirects user to the Pylons Wallet page on the Store.
+  void goToInstall();
+
   /// Async: Retrieves the cookbook with provided ID [id].
   ///
   /// Response's data field is the retrieved [Cookbook].

--- a/lib/src/pylons_wallet/pylons_wallet_impl.dart
+++ b/lib/src/pylons_wallet/pylons_wallet_impl.dart
@@ -211,6 +211,17 @@ class PylonsWalletImpl implements PylonsWallet {
     });
   }
 
+  @override
+  void goToInstall() async {
+    var _url = '';
+    if (Platform.isAndroid) {
+      _url = kPlayStoreUrl;
+    } else {
+      _url = kAppStoreUrl;
+    }
+    await canLaunch(_url) ? await launch(_url) : throw 'Could not launch $_url';
+  }
+
   /// Sends [unilink] to wallet app.
   ///
   /// Throws a [NoWalletException] if the wallet doesn't exist.

--- a/test/pylons_wallet/pylons_wallet_impl_test.dart
+++ b/test/pylons_wallet/pylons_wallet_impl_test.dart
@@ -32,6 +32,18 @@ void main() {
   getExecutionByIdTest();
   getTradesTest();
   placeForSaleTest();
+  goToInstallTest();
+}
+
+void goToInstallTest() {
+  test('should redirect to the Store page where the Pylons app can be downloaded', () async {
+    mockChannelHandler();
+    var uniLink = MockUniLinksPlatform();
+    when(uniLink.linkStream)
+        .thenAnswer((realInvocation) => Stream<String?>.value('Jawad'));
+    var pylonsWallet = PylonsWalletImpl(host: MOCK_HOST, uniLink: uniLink);
+    pylonsWallet.goToInstall();
+  });
 }
 
 void placeForSaleTest() {

--- a/test/pylons_wallet/pylons_wallet_impl_test.dart
+++ b/test/pylons_wallet/pylons_wallet_impl_test.dart
@@ -36,7 +36,9 @@ void main() {
 }
 
 void goToInstallTest() {
-  test('should redirect to the Store page where the Pylons app can be downloaded', () async {
+  test(
+      'should redirect to the Store page where the Pylons app can be downloaded',
+      () async {
     mockChannelHandler();
     var uniLink = MockUniLinksPlatform();
     when(uniLink.linkStream)


### PR DESCRIPTION
Third-party apps like Easel can just use this function to go to the Store, instead of having to define a separate function themselves. Once we deploy newer version of sdk, I'll fix the Easel so it will use sdk func instead.