### PR TITLE
:bug: update package name, kotlin version, compile sdk

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
 
     <queries>
-        <package android:name="xyz.pylons.wallet" />
+        <package android:name="tech.pylons.wallet" />
     </queries>
 
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This fixes android issue where the `pylons sdk` won't work. Updating the package name in the `manifest`, `kotlin version` and `compile sdk version` fixed the error me and Christine was getting.